### PR TITLE
Boxing TOC entries

### DIFF
--- a/src/outline-summaryst.typ
+++ b/src/outline-summaryst.typ
@@ -37,7 +37,7 @@
       
       // style h1's differently from lower level headings
       if lvl == 1 {
-        return link(loc)[
+        return box(link(loc)[
           #v(30pt)
           #set align(center)
           #smallcaps[#text(
@@ -46,10 +46,10 @@
           
           #set align(left)
           #subcnt
-        ]
+        ])
       }
       // else
-      return link(loc)[
+      return box(link(loc)[
         #let size = calc-elem-size(it.element)
         
         #set align(center)
@@ -60,7 +60,7 @@
         #set align(left)
         
         #subcnt #box(width: 1fr, repeat[.]) #it.page
-      ]
+      ])
     }
     
     elemcounter.step()


### PR DESCRIPTION
Boxing TOC entries prevents splitting the entry over the page boundary.